### PR TITLE
chore(node): set support node engines v6.9.0 higher

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
   "dependencies": {
     "hexo-pagination": "0.0.2",
     "object-assign": "^4.0.1"
+  },
+  "engines": {
+    "node": ">=6.9.0"
   }
 }


### PR DESCRIPTION
## Proposal

Set node engines v6.9.0 same as [main repository](https://github.com/hexojs/hexo/blob/bb443d5f0efe91e880a653ccaff66548ee642702/package.json#L78).