### PR TITLE
refactor(package): use Object.assign instead of object-assign package…

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,9 +2,7 @@
 
 'use strict';
 
-var assign = require('object-assign');
-
-hexo.config.category_generator = assign({
+hexo.config.category_generator = Object.assign({
   per_page: typeof hexo.config.per_page === 'undefined' ? 10 : hexo.config.per_page
 }, hexo.config.category_generator);
 

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
     "istanbul": "^0.4.2"
   },
   "dependencies": {
-    "hexo-pagination": "0.0.2",
-    "object-assign": "^4.0.1"
+    "hexo-pagination": "0.0.2"
   },
   "engines": {
     "node": ">=6.9.0"


### PR DESCRIPTION
## Proposal

Use Object.assign instead of object-assign package

## Reason

Node.js 4 and up can be use Object.assign() instead of object-assign npm package.
This repository is already set node engine higher than 6.9.0 .
So, it can use Object.assign() .