### PR TITLE
chore: drop node.js 8.x, 10.x & update hexo to 6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "coveralls": "^3.0.2",
     "eslint": "^7.1.0",
     "eslint-config-hexo": "^4.1.0",
-    "hexo": "^5.0.2",
+    "hexo": "^6.0.0",
     "mocha": "^8.0.1",
     "nyc": "^15.0.0"
   },
@@ -37,6 +37,6 @@
     "hexo-pagination": "2.0.0"
   },
   "engines": {
-    "node": ">=8.6.0"
+    "node": ">=12.13.0"
   }
 }


### PR DESCRIPTION
As is the title.
We need to bump hexo to `6.0.0` to pass the test. Above node 12.x all tests are failure if we do not bump to hexo `6.0.0`.

Thank you :)