### PR TITLE
added "explicit_paging" and "overwrite_latest" options

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ category_generator:
 - **per_page**: Posts displayed per page. (0 = disable pagination)
 - **order_by**: Posts order. (Order by date descending by default)
 - **explicit_paging**: Explicit paging. (Number the first page. e.g. `page/1/index.html`)
-- **overwrite_latest**: Set the latest page. (`latest/index.html` in place of `page/N/index.html`)
+- **overwrite_latest**: Set the latest page. (`latest/index.html` in place of `page/N/index.html`). If there is a single page it requires explicitPaging=true`.
 - **verbose**: verbose output. (Output all generated routes)
 
 ## License

--- a/README.md
+++ b/README.md
@@ -18,10 +18,16 @@ $ npm install hexo-generator-category --save
 category_generator:
   per_page: 10
   order_by: -date
+  explicit_paging: false
+  overwrite_latest: false
+  verbose: false
 ```
 
 - **per_page**: Posts displayed per page. (0 = disable pagination)
 - **order_by**: Posts order. (Order by date descending by default)
+- **explicit_paging**: Explicit paging. (Number the first page. e.g. `page/1/index.html`)
+- **overwrite_latest**: Set the latest page. (`latest/index.html` in place of `page/N/index.html`)
+- **verbose**: verbose output. (Output all generated routes)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -19,14 +19,16 @@ category_generator:
   per_page: 10
   order_by: -date
   explicit_paging: false
-  overwrite_latest: false
+  rename_last: false
+  localized_last: 'last'
   verbose: false
 ```
 
 - **per_page**: Posts displayed per page. (0 = disable pagination)
 - **order_by**: Posts order. (Order by date descending by default)
 - **explicit_paging**: Explicit paging. (Number the first page. e.g. `page/1/index.html`)
-- **overwrite_latest**: Set the latest page. (`latest/index.html` in place of `page/N/index.html`). If there is a single page it requires explicitPaging=true`.
+- **rename_last**: Set the latest page name. (`page/last/index.html` in place of `page/N/index.html`). If there is a single page it requires explicit_paging=true`.
+- **localized_last**: Localize the last page name. (`page/最後/index.html` in place of `page/last/index.html`).
 - **verbose**: verbose output. (Output all generated routes)
 
 ## License

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -5,6 +5,9 @@ const pagination = require('hexo-pagination');
 module.exports = function(locals) {
   const config = this.config;
   const perPage = config.category_generator.per_page;
+  const explicitPaging = config.category_generator.explicit_paging || false;
+  const overwriteLatest = config.category_generator.overwrite_latest || false;
+  const verbose = config.category_generator.verbose || false;
   const paginationDir = config.pagination_dir || 'page';
   const orderBy = config.category_generator.order_by || '-date';
 
@@ -16,22 +19,13 @@ module.exports = function(locals) {
       perPage,
       layout: ['category', 'archive', 'index'],
       format: paginationDir + '/%d/',
-      explicitPaging: (config.category_generator.explicit_paging || config.category_generator.overwrite_latest || false),
+      explicitPaging: explicitPaging,
+      overwriteLatest: overwriteLatest,
+      verbose: verbose,
       data: {
         category: category.name
       }
     });
-
-    if ((config.category_generator.overwrite_latest || false) && data.length > 0) {
-      const lastPage = data[data.length - 1];
-      lastPage.path = lastPage.path.replace(/\/page\/\d+\/?$/, '/latest/');
-    }
-
-    if (config.category_generator.verbose || false) {
-      data.forEach(page => {
-        console.log(`Generated category route: ${page.path}`);
-      });
-    }
 
     return result.concat(data);
   }, []);

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -6,7 +6,8 @@ module.exports = function(locals) {
   const config = this.config;
   const perPage = config.category_generator.per_page;
   const explicitPaging = config.category_generator.explicit_paging || false;
-  const overwriteLatest = config.category_generator.overwrite_latest || false;
+  const renameLast = config.category_generator.rename_last || false;
+  const localizedLast = config.category_generator.localized_last || 'last';
   const verbose = config.category_generator.verbose || false;
   const paginationDir = config.pagination_dir || 'page';
   const orderBy = config.category_generator.order_by || '-date';
@@ -20,7 +21,8 @@ module.exports = function(locals) {
       layout: ['category', 'archive', 'index'],
       format: paginationDir + '/%d/',
       explicitPaging: explicitPaging,
-      overwriteLatest: overwriteLatest,
+      renameLast: renameLast,
+      localizedLast: localizedLast,
       verbose: verbose,
       data: {
         category: category.name

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -16,10 +16,22 @@ module.exports = function(locals) {
       perPage,
       layout: ['category', 'archive', 'index'],
       format: paginationDir + '/%d/',
+      explicitPaging: (config.category_generator.explicit_paging || config.category_generator.overwrite_latest || false),
       data: {
         category: category.name
       }
     });
+
+    if ((config.category_generator.overwrite_latest || false) && data.length > 0) {
+      const lastPage = data[data.length - 1];
+      lastPage.path = lastPage.path.replace(/\/page\/\d+\/?$/, '/latest/');
+    }
+
+    if (config.category_generator.verbose || false) {
+      data.forEach(page => {
+        console.log(`Generated category route: ${page.path}`);
+      });
+    }
 
     return result.concat(data);
   }, []);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-generator-category",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Category generator for Hexo.",
   "main": "index",
   "scripts": {
@@ -34,7 +34,7 @@
     "mocha": "^10.0.0"
   },
   "dependencies": {
-    "hexo-pagination": "3.0.0"
+    "hexo-pagination": "4.0.0"
   },
   "engines": {
     "node": ">=14"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-generator-category",
-  "version": "2.1.0",
+  "version": "2.0.0",
   "description": "Category generator for Hexo.",
   "main": "index",
   "scripts": {


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo!
-->

## check list

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.

## Description

Adding a flag for `explicitPaging` introduced in the version 4.0.0 of hexo-pagination. hexojs/hexo-pagination#114
Adding the option to have the last page to be `latest` which is convenient in case of reverse pagination.

## Additional information
